### PR TITLE
Removing separate concurrency from sdwebimageprefetcher, and adding a wa...

### DIFF
--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -218,6 +218,13 @@ SDWebImageManager *manager = [SDWebImageManager sharedManager];
 - (void)cancelAll;
 
 /**
+ Cancels the given operations if they are running in this manager.
+
+ @param operations The operations to cancel.
+ */
+- (void)cancelOperations:(NSArray *)operations;
+
+/**
  * Check one or more operations running
  */
 - (BOOL)isRunning;

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -290,6 +290,18 @@
     }
 }
 
+- (void)cancelOperations:(NSArray *)operations
+{
+    @synchronized (self.runningOperations) {
+        NSArray *operationsToCancel = [self.runningOperations filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(NSOperation *evaluatedObject, NSDictionary *bindings) {
+            return [operations containsObject:evaluatedObject];
+        }]];
+
+        [operationsToCancel makeObjectsPerformSelector:@selector(cancel)];
+        [self.runningOperations removeObjectsInArray:operationsToCancel];
+    }
+}
+
 - (BOOL)isRunning {
     return self.runningOperations.count > 0;
 }

--- a/SDWebImage/SDWebImagePrefetcher.h
+++ b/SDWebImage/SDWebImagePrefetcher.h
@@ -58,17 +58,12 @@ typedef void(^SDWebImagePrefetcherCompletionBlock)(NSUInteger noOfFinishedUrls, 
  */
 @property (nonatomic, assign) SDWebImageOptions options;
 
-/**
- * Queue options for Prefetcher. Defaults to Main Queue.
- */
-@property (nonatomic, assign) dispatch_queue_t prefetcherQueue;
-
 @property (weak, nonatomic) id <SDWebImagePrefetcherDelegate> delegate;
 
 /**
  * Return the global image prefetcher instance.
  */
-+ (SDWebImagePrefetcher *)sharedImagePrefetcher;
++ (instancetype)sharedImagePrefetcher;
 
 /**
  * Assign list of URLs to let SDWebImagePrefetcher to queue the prefetching,
@@ -98,6 +93,13 @@ typedef void(^SDWebImagePrefetcherCompletionBlock)(NSUInteger noOfFinishedUrls, 
  * Remove and cancel queued list
  */
 - (void)cancelPrefetching;
+
+/**
+ cancels prefetching the given url if this prefetcher is currently or is queued to download it.
+
+ @param url the URL to cancel.
+ */
+- (void)cancelPrefetchingForURL:(NSURL *)url;
 
 
 @end


### PR DESCRIPTION
...y to cancel a specific set of operations in the image manager

This should simplify prefetching and make it easier to prefetch multiple sets of images with the same prefetcher object
